### PR TITLE
Added youtube embedding to bbCode options

### DIFF
--- a/angularjs-bbcode.js
+++ b/angularjs-bbcode.js
@@ -15,6 +15,7 @@ angular.module('bbModule', [])
 		"img=([^\\[\\]<>]+?)": "<img src=\"$1\" alt=\"$2\" />",											// Image with title
 		"url": "<a href=\"$1\" target=\"_blank\" title=\"$1\">$1</a>",									// Simple URL
 		"url=([^\\[\\]<>]+?)": "<a href=\"$1\" target=\"_blank\" title=\"$2\">$2</a>",					// URL with title
+		"media=https?:\\/\\/.*(youtube\\.com\\/watch\\?v=([^&\\?\\]]+).*)": "<iframe width=\"560\" height=\"315\" src=\"https://www.youtube.com/embed/$2\"></iframe>",	//youtube video embedding
 		"style": function(complete, y) {																// Example of function use
 			return y.toUpperCase();
 		}
@@ -29,8 +30,7 @@ angular.module('bbModule', [])
 					var contents = $element.html().replace(/^\s+|\s+$/i, '');
 
 					for(var i in snippets) {
-						var regexp = new RegExp('\\[' + i + '\\](.+?)\\[\/' + i.replace(/[^a-z]/g, '') + '\\]', 'gi');
-
+						var regexp = new RegExp('\\[' + i + '\\](.+?)?\\[\/' + i.replace(/=.*/g, '') + '\\]', 'gi');
 						contents = contents.replace(regexp, snippets[i]);
 					}
 

--- a/testapp.js
+++ b/testapp.js
@@ -3,5 +3,5 @@
 
 angular.module('testApp', ['bbModule'])
 .controller('testController', ['$scope', function($scope) {
-	$scope.text = "Dies ist [b]fetter[/b] Text.\nDies ist [I]kursiver[/I] Text.\nDies ist [U]unterstrichener[/U] Text.\nDies ist [S]durchgestrichener[/S] Text.\n\n[URL]http://www.example.com[/URL]\nDann Farben : [color=#FF0000]ganz rot![/color]";
+	$scope.text = "Dies ist [b]fetter[/b] Text.\nDies ist [I]kursiver[/I] Text.\nDies ist [U]unterstrichener[/U] Text.\nDies ist [S]durchgestrichener[/S] Text.\n\n[URL]http://www.example.com[/URL]\nDann Farben : [color=#FF0000]ganz rot![/color][media=https://www.youtube.com/watch?v=Y05wiQQbFLU][/media]";
 }]);

--- a/testapp.js
+++ b/testapp.js
@@ -3,5 +3,5 @@
 
 angular.module('testApp', ['bbModule'])
 .controller('testController', ['$scope', function($scope) {
-	$scope.text = "Dies ist [b]fetter[/b] Text.\nDies ist [I]kursiver[/I] Text.\nDies ist [U]unterstrichener[/U] Text.\nDies ist [S]durchgestrichener[/S] Text.\n\n[URL]http://www.example.com[/URL]\nDann Farben : [color=#FF0000]ganz rot![/color][media=https://www.youtube.com/watch?v=Y05wiQQbFLU][/media]";
+	$scope.text = "Dies ist [b]fetter[/b] Text.\nDies ist [I]kursiver[/I] Text.\nDies ist [U]unterstrichener[/U] Text.\nDies ist [S]durchgestrichener[/S] Text.\n\n[URL]http://www.example.com[/URL]\nDann Farben : [color=#FF0000]ganz rot![/color][media=https://www.youtube.com/watch?v=3bNITQR4Uso][/media]";
 }]);


### PR DESCRIPTION
The following changes have been made:

- Use the [media=(url)][/media] tag to embed youtube videos. The youtube URL must be in the format of https://www.youtube.com/watch?v=[videoId]. youtu.be links are not supported right now, but may be in the future with another, separate regex

- Content INSIDE tags is optional. Previous, a tag such as [b][/b] would be illegal, but now, to support media tags with empty bodies, this is now allowed

- Regular expressions are changed to remove all content matching /=.*/ in the closing bbCode tag.